### PR TITLE
Implement JNI to JSI conversion for primitive Java Arrays:

### DIFF
--- a/package/android/src/main/cpp/frameprocessors/JSIJNIConversion.cpp
+++ b/package/android/src/main/cpp/frameprocessors/JSIJNIConversion.cpp
@@ -177,6 +177,69 @@ jsi::Value JSIJNIConversion::convertJNIObjectToJSIValue(jsi::Runtime& runtime, c
 
     std::shared_ptr<jsi::ArrayBuffer> array = sharedArray->cthis()->getArrayBuffer();
     return array->getArrayBuffer(runtime);
+  } else if (object->isInstanceOf(JArrayInt::javaClassStatic())) {
+      auto array = static_ref_cast<JArrayInt>(object);
+      auto pinned = array->pin();
+      auto size = pinned.size();
+      auto result = jsi::Array(runtime, size);
+
+      for (int i = 0; i < size; i += 1) {
+          auto item = pinned[i];
+          result.setValueAtIndex(runtime, i, jsi::Value(item));
+      }
+
+      pinned.release();
+      return result;
+  } else if (object->isInstanceOf(JArrayDouble::javaClassStatic())) {
+      auto array = static_ref_cast<JArrayDouble>(object);
+      auto pinned = array->pin();
+      auto size = pinned.size();
+      auto result = jsi::Array(runtime, size);
+
+      for (int i = 0; i < size; i += 1) {
+          auto item = pinned[i];
+          result.setValueAtIndex(runtime, i, jsi::Value(item));
+      }
+
+      pinned.release();
+      return result;
+  } else if (object->isInstanceOf(JArrayFloat ::javaClassStatic())) {
+      auto array = static_ref_cast<JArrayFloat>(object);
+      auto pinned = array->pin();
+      auto size = pinned.size();
+      auto result = jsi::Array(runtime, size);
+
+      for (int i = 0; i < size; i += 1) {
+          auto item = pinned[i];
+          result.setValueAtIndex(runtime, i, jsi::Value(item));
+      }
+
+      pinned.release();
+      return result;
+  } else if (object->isInstanceOf(JArrayBoolean ::javaClassStatic())) {
+      auto array = static_ref_cast<JArrayBoolean>(object);
+      auto pinned = array->pin();
+      auto size = pinned.size();
+      auto result = jsi::Array(runtime, size);
+
+      for (int i = 0; i < size; i += 1) {
+          bool item = pinned[i];
+          result.setValueAtIndex(runtime, i, jsi::Value(item));
+      }
+
+      pinned.release();
+      return result;
+  } else if (object->isInstanceOf(JArrayClass<jobject>::javaClassStatic())) {
+      auto array = static_ref_cast<JArrayClass<jobject>>(object);
+      auto size = array->size();
+      auto result = jsi::Array(runtime, size);
+
+      for (int i = 0; i < size; i += 1) {
+          auto item = array->getElement(i);
+          result.setValueAtIndex(runtime, i,  convertJNIObjectToJSIValue(runtime, item));
+      }
+
+      return result;
   }
 
   auto type = object->getClass()->toString();

--- a/package/example/android/app/src/main/java/com/mrousavy/camera/example/ExampleFrameProcessorPlugin.java
+++ b/package/example/android/app/src/main/java/com/mrousavy/camera/example/ExampleFrameProcessorPlugin.java
@@ -50,6 +50,17 @@ public class ExampleFrameProcessorPlugin extends FrameProcessorPlugin {
         byteBuffer.put(0, (byte)(Math.random() * 100));
         map.put("example_array_buffer", _sharedArray);
 
+        int[] primitiveIntArray = new int[]{ 10, 20 };
+        double[] primitiveDoubleArray = new double[]{20.5, 20.3};
+        float[] primitiveFloatArray = new float[]{30.3f, 60.5f};
+        boolean[] primitiveBooleanArray = new boolean[]{true, false, true, true};
+        int[][] arrayOfIntArray = new int[][]{new int[]{15, 20}, new int[]{5, 10}};
+        map.put("primitive_int_array", primitiveIntArray);
+        map.put("primitive_double_array", primitiveDoubleArray);
+        map.put("primitive_float_array", primitiveFloatArray);
+        map.put("primitive_boolean_array", primitiveBooleanArray);
+        map.put("array_of_primitive_int_array", arrayOfIntArray);
+
         return map;
     }
 


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What
Implement JNI to JSI conversion for primitive Java Arrays:
* `JArrayInt`
* `JArrayDouble`
* `JArrayFloat`
* `JArrayBoolean`
* `JArrayClass<jobject>`


## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
